### PR TITLE
Support for copying between Armatures with different Scale

### DIFF
--- a/Scripts/Editor/Copiers/LegacyCopier.cs
+++ b/Scripts/Editor/Copiers/LegacyCopier.cs
@@ -98,7 +98,7 @@ namespace Pumkin.AvatarTools.Copiers
                     {
                         var d = dbcToArr[z];
                         if(d.m_Bound == dbcFrom.m_Bound && d.m_Center == dbcFrom.m_Center &&
-                            d.m_Direction == dbcFrom.m_Direction && d.m_Height == dbcFrom.m_Height && d.m_Radius == dbcFrom.m_Radius)
+                           d.m_Direction == dbcFrom.m_Direction && d.m_Height == dbcFrom.m_Height && d.m_Radius == dbcFrom.m_Radius)
                         {
                             found = true;
                             break;
@@ -109,17 +109,15 @@ namespace Pumkin.AvatarTools.Copiers
                     {
                         ComponentUtility.CopyComponent(dbcFrom);
                         ComponentUtility.PasteComponentAsNew(tTo.gameObject);
+                        DynamicBoneCollider dbcTo = tTo.GetComponent<DynamicBoneCollider>();
 
                         if (adjustScale)
                         {
-                            for(int z = 0; z < dbcToArr.Length; z++)
-                            {
-                                var d = dbcToArr[z];
-                                float scaleMu = Helpers.GetScaleMultiplier(dbcFrom.transform, d.transform);
-                                d.m_Center *= scaleMu;
-                                d.m_Height *= scaleMu;
-                                d.m_Radius *= scaleMu;
-                            }
+                            float scaleMu = Helpers.GetScaleMultiplier(dbcFrom.transform, dbcTo.transform );
+                            dbcTo.m_Center *= scaleMu;
+                            dbcTo.m_Height *= scaleMu;
+                            dbcTo.m_Radius *= scaleMu;
+                            dbcTo.transform.localPosition *= scaleMu;
                         }
                     }
                 }
@@ -351,7 +349,7 @@ namespace Pumkin.AvatarTools.Copiers
         /// </summary>
         /// <param name="from"></param>
         /// <param name="to"></param>
-        internal static void CopyAllColliders(GameObject from, GameObject to, bool createGameObjects, bool useIgnoreList)
+        internal static void CopyAllColliders(GameObject from, GameObject to, bool createGameObjects, bool useIgnoreList, bool adjustScale)
         {
             if(from == null || to == null)
                 return;
@@ -397,6 +395,28 @@ namespace Pumkin.AvatarTools.Copiers
                         ComponentUtility.CopyComponent(cFromArr[i]);
                         ComponentUtility.PasteComponentAsNew(cToObj);
 
+                        if (adjustScale)
+                        {
+                            float mul = Helpers.GetScaleMultiplier(cFromArr[i].transform, cToObj.transform);
+                            if (cToObj.TryGetComponent(out SphereCollider sphere))
+                            {
+                                sphere.center *= mul;
+                                sphere.radius *= mul;
+                            }
+                            if (cToObj.TryGetComponent(out BoxCollider box))
+                            {
+                                box.center *= mul;
+                                box.size *= mul;
+                            }
+                            if (cToObj.TryGetComponent(out CapsuleCollider capsule))
+                            {
+                                capsule.center *= mul;
+                                capsule.radius *= mul;
+                                capsule.height *= mul;
+                            }
+                            cToObj.transform.localPosition *= mul;
+                        }
+                        
                         PumkinsAvatarTools.Log(log + " - " + Strings.Log.success, LogType.Log, type.ToString(), cFromArr[i].gameObject.name, cToObj.name);
                     }
                 }

--- a/Scripts/Editor/Copiers/LegacyCopier.cs
+++ b/Scripts/Editor/Copiers/LegacyCopier.cs
@@ -69,7 +69,7 @@ namespace Pumkin.AvatarTools.Copiers
         /// <summary>
         /// Copies all DynamicBoneColliders from object and it's children to another object.
         /// </summary>
-        internal static void CopyAllDynamicBoneColliders(GameObject from, GameObject to, bool createGameObjects, bool useIgnoreList)
+        internal static void CopyAllDynamicBoneColliders(GameObject from, GameObject to, bool createGameObjects, bool useIgnoreList, bool adjutScale)
         {
 #if !PUMKIN_DBONES && !PUMKIN_OLD_DBONES
 
@@ -109,6 +109,20 @@ namespace Pumkin.AvatarTools.Copiers
                     {
                         ComponentUtility.CopyComponent(dbcFrom);
                         ComponentUtility.PasteComponentAsNew(tTo.gameObject);
+
+                        if (adjustScale)
+                        {
+                            for(int z = 0; z < dbcToArr.Length; z++)
+                            {
+                                var d = dbcToArr[z];
+                                Vector3 scaleMu = GetScaleMultiplier(dbcFrom.transform, d.transform)
+                                d.m_Bound *= scaleMu
+                                d.m_Center *= scaleMu
+                                d.m_Direction *= scaleMu
+                                d.m_Height *= scaleMu
+                                d.m_Radius *= scaleMu
+                            }
+                        }
                     }
                 }
             }
@@ -122,7 +136,7 @@ namespace Pumkin.AvatarTools.Copiers
         /// <param name="to"></param>
         /// <param name="createMissing"></param>
         /// <param name="useIgnoreList"></param>
-        internal static void CopyAllDynamicBonesNew(GameObject from, GameObject to, bool createMissing, bool useIgnoreList)
+        internal static void CopyAllDynamicBonesNew(GameObject from, GameObject to, bool createMissing, bool useIgnoreList, bool adjustScale)
         {
 #if !PUMKIN_DBONES && !PUMKIN_OLD_DBONES
             Debug.Log("No DynamicBones found in project. You shouldn't be able to use this. Help!");
@@ -227,6 +241,14 @@ namespace Pumkin.AvatarTools.Copiers
                                 bone.m_StiffnessDistrib = dbFrom.m_StiffnessDistrib;
 
                                 bone.m_ReferenceObject = Helpers.FindTransformInAnotherHierarchy(dbFrom.m_ReferenceObject, bone.transform, false);
+                            
+                                if (adjustScale)
+                                {
+                                    Vector3 scaleMul = GetScaleMultiplier(dbFrom.transform, bone.transform)
+                                    bone.m_Radius *= scaleMul
+                                    bone.m_EndLength *= scaleMul
+                                    bone.m_EndOffset *= scaleMul
+                                }
                             }
                             else
                             {
@@ -246,6 +268,14 @@ namespace Pumkin.AvatarTools.Copiers
                         var newDynBone = transTo.gameObject.AddComponent<DynamicBone>();
                         ComponentUtility.CopyComponent(dbFrom);
                         ComponentUtility.PasteComponentValues(newDynBone);
+
+                        if (adjustScale)
+                        {
+                            Vector3 scaleMul = GetScaleMultiplier(dbFrom.transform, bone.transform)
+                            bone.m_Radius *= scaleMul
+                            bone.m_EndLength *= scaleMul
+                            bone.m_EndOffset *= scaleMul
+                        }
 
                         newDynBone.m_Root = Helpers.FindTransformInAnotherHierarchy(dbFrom.m_Root.transform, newDynBone.transform.root, false);
 

--- a/Scripts/Editor/Copiers/LegacyCopier.cs
+++ b/Scripts/Editor/Copiers/LegacyCopier.cs
@@ -69,7 +69,7 @@ namespace Pumkin.AvatarTools.Copiers
         /// <summary>
         /// Copies all DynamicBoneColliders from object and it's children to another object.
         /// </summary>
-        internal static void CopyAllDynamicBoneColliders(GameObject from, GameObject to, bool createGameObjects, bool useIgnoreList, bool adjutScale)
+        internal static void CopyAllDynamicBoneColliders(GameObject from, GameObject to, bool createGameObjects, bool useIgnoreList, bool adjustScale)
         {
 #if !PUMKIN_DBONES && !PUMKIN_OLD_DBONES
 
@@ -115,12 +115,10 @@ namespace Pumkin.AvatarTools.Copiers
                             for(int z = 0; z < dbcToArr.Length; z++)
                             {
                                 var d = dbcToArr[z];
-                                Vector3 scaleMu = GetScaleMultiplier(dbcFrom.transform, d.transform)
-                                d.m_Bound *= scaleMu
-                                d.m_Center *= scaleMu
-                                d.m_Direction *= scaleMu
-                                d.m_Height *= scaleMu
-                                d.m_Radius *= scaleMu
+                                float scaleMu = Helpers.GetScaleMultiplier(dbcFrom.transform, d.transform);
+                                d.m_Center *= scaleMu;
+                                d.m_Height *= scaleMu;
+                                d.m_Radius *= scaleMu;
                             }
                         }
                     }
@@ -244,10 +242,10 @@ namespace Pumkin.AvatarTools.Copiers
                             
                                 if (adjustScale)
                                 {
-                                    Vector3 scaleMul = GetScaleMultiplier(dbFrom.transform, bone.transform)
-                                    bone.m_Radius *= scaleMul
-                                    bone.m_EndLength *= scaleMul
-                                    bone.m_EndOffset *= scaleMul
+                                    float scaleMul = Helpers.GetScaleMultiplier(dbFrom.transform, bone.transform);
+                                    bone.m_Radius *= scaleMul;
+                                    bone.m_EndLength *= scaleMul;
+                                    bone.m_EndOffset *= scaleMul;
                                 }
                             }
                             else
@@ -271,10 +269,10 @@ namespace Pumkin.AvatarTools.Copiers
 
                         if (adjustScale)
                         {
-                            Vector3 scaleMul = GetScaleMultiplier(dbFrom.transform, bone.transform)
-                            bone.m_Radius *= scaleMul
-                            bone.m_EndLength *= scaleMul
-                            bone.m_EndOffset *= scaleMul
+                            float scaleMul = Helpers.GetScaleMultiplier(dbFrom.transform, newDynBone.transform);
+                            newDynBone.m_Radius *= scaleMul;
+                            newDynBone.m_EndLength *= scaleMul;
+                            newDynBone.m_EndOffset *= scaleMul;
                         }
 
                         newDynBone.m_Root = Helpers.FindTransformInAnotherHierarchy(dbFrom.m_Root.transform, newDynBone.transform.root, false);

--- a/Scripts/Editor/Data/PumkinsStrings.cs
+++ b/Scripts/Editor/Data/PumkinsStrings.cs
@@ -396,6 +396,7 @@ namespace Pumkin.DataStructures
             public static string colliders_capsule = "_Capsule Colliders";
             public static string colliders_sphere = "_Sphere Colliders";
             public static string colliders_mesh = "_Mesh Colliders";
+            public static string colliders_adjustScale = "_Adjust Scale";
             public static string colliders_removeOld = "_Remove Old Colliders";
             public static string descriptor = "_Avatar Descriptor";
             public static string descriptor_pipelineId = "_Pipeline Id";
@@ -470,12 +471,15 @@ namespace Pumkin.DataStructures
                 dynamicBones_removeOldBones = Translation.copier.dynamicBones_removeOldBones;
                 dynamicBones_removeOldColliders = Translation.copier.dynamicBones_removeOldColliders;
                 dynamicBones_createMissing = Translation.copier.dynamicBones_createMissing;
+                dynamicBones_adjustScale = Translation.copier.dynamicBones_adjustScale;
+                dynamicBones_adjustScaleColliders = Translation.copier.dynamicBones_adjustScaleColliders;
                 colliders = Translation.copier.colliders;
                 colliders_box = Translation.copier.colliders_box;
                 colliders_capsule = Translation.copier.colliders_capsule;
                 colliders_sphere = Translation.copier.colliders_sphere;
                 colliders_mesh = Translation.copier.colliders_mesh;
                 colliders_removeOld = Translation.copier.colliders_removeOld;
+                colliders_adjustScale = Translation.copier.colliders_adjustScale;
 
                 descriptor = Translation.copier.descriptor;
                 descriptor_pipelineId = Translation.copier.descriptor_pipelineId;

--- a/Scripts/Editor/Data/PumkinsStrings.cs
+++ b/Scripts/Editor/Data/PumkinsStrings.cs
@@ -389,8 +389,8 @@ namespace Pumkin.DataStructures
             public static string dynamicBones_removeOldBones = "_Remove Old Dynamic Bones";
             public static string dynamicBones_removeOldColliders = "_Remove Old Colliders";
             public static string dynamicBones_createMissing = "_Create Missing Dynamic Bones";
-            public static string dynamicBones_adjustScale = "_  EXPERIMENTAL! adjust Scale";
-            public static string dynamicBones_adjustScaleColliders = "_EXPERIMENTAL! adjust Scale";
+            public static string dynamicBones_adjustScale = "_Adjust Scale";
+            public static string dynamicBones_adjustScaleColliders = "_Adjust Scale";
             public static string colliders = "_Colliders";
             public static string colliders_box = "_Box Colliders";
             public static string colliders_capsule = "_Capsule Colliders";

--- a/Scripts/Editor/Data/PumkinsStrings.cs
+++ b/Scripts/Editor/Data/PumkinsStrings.cs
@@ -389,6 +389,8 @@ namespace Pumkin.DataStructures
             public static string dynamicBones_removeOldBones = "_Remove Old Dynamic Bones";
             public static string dynamicBones_removeOldColliders = "_Remove Old Colliders";
             public static string dynamicBones_createMissing = "_Create Missing Dynamic Bones";
+            public static string dynamicBones_adjustScale = "_  EXPERIMENTAL! adjust Scale";
+            public static string dynamicBones_adjustScaleColliders = "_EXPERIMENTAL! adjust Scale";
             public static string colliders = "_Colliders";
             public static string colliders_box = "_Box Colliders";
             public static string colliders_capsule = "_Capsule Colliders";

--- a/Scripts/Editor/Helpers/PumkinsHelperFunctions.cs
+++ b/Scripts/Editor/Helpers/PumkinsHelperFunctions.cs
@@ -1056,6 +1056,14 @@ namespace Pumkin.HelperFunctions
         }
 
         /// <summary>
+        /// Calculates Scale Multiplier.
+        /// </summary>
+        public static Vector3 GetScaleMultiplier(Transform to, Transform from)
+        {
+            return to.lossyscale / from.lossyScale;
+        }
+
+        /// <summary>
         /// Returns true if GameObject has no children or components
         /// </summary>
         public static bool GameObjectIsEmpty(GameObject obj)

--- a/Scripts/Editor/Helpers/PumkinsHelperFunctions.cs
+++ b/Scripts/Editor/Helpers/PumkinsHelperFunctions.cs
@@ -1058,9 +1058,9 @@ namespace Pumkin.HelperFunctions
         /// <summary>
         /// Calculates Scale Multiplier.
         /// </summary>
-        public static Vector3 GetScaleMultiplier(Transform to, Transform from)
+        public static float GetScaleMultiplier(Transform to, Transform from)
         {
-            return to.lossyscale / from.lossyScale;
+            return to.lossyScale.x / from.lossyScale.x;
         }
 
         /// <summary>

--- a/Scripts/Editor/Helpers/PumkinsHelperFunctions.cs
+++ b/Scripts/Editor/Helpers/PumkinsHelperFunctions.cs
@@ -1058,9 +1058,9 @@ namespace Pumkin.HelperFunctions
         /// <summary>
         /// Calculates Scale Multiplier.
         /// </summary>
-        public static float GetScaleMultiplier(Transform to, Transform from)
+        public static float GetScaleMultiplier(Transform from, Transform to)
         {
-            return to.lossyScale.x / from.lossyScale.x;
+            return from.lossyScale.x / to.lossyScale.x;
         }
 
         /// <summary>

--- a/Scripts/Editor/PumkinsAvatarTools.cs
+++ b/Scripts/Editor/PumkinsAvatarTools.cs
@@ -1795,6 +1795,7 @@ namespace Pumkin.AvatarTools
 
                                     EditorGUILayout.Space();
 
+                                    Settings.bCopier_colliders_removeOld = GUILayout.Toggle(Settings.bCopier_colliders_adjustScale, Strings.Copier.colliders_adjustScale, Styles.CopierToggle);
                                     Settings.bCopier_colliders_removeOld = GUILayout.Toggle(Settings.bCopier_colliders_removeOld, Strings.Copier.colliders_removeOld, Styles.CopierToggle);
                                     Settings.bCopier_colliders_createObjects = GUILayout.Toggle(Settings.bCopier_colliders_createObjects, Strings.Copier.copyGameObjects, Styles.CopierToggle);
                                 }
@@ -4448,7 +4449,7 @@ namespace Pumkin.AvatarTools
             {
                 if(Settings.bCopier_colliders_removeOld)
                     LegacyDestroyer.DestroyAllComponentsOfType(objTo, typeof(Collider), false, true);
-                LegacyCopier.CopyAllColliders(objFrom, objTo, Settings.bCopier_colliders_createObjects, true);
+                LegacyCopier.CopyAllColliders(objFrom, objTo, Settings.bCopier_colliders_createObjects, true, Settings.bCopier_colliders_adjustScale);
             }
             if(Settings.bCopier_rigidBodies_copy && CopierTabs.ComponentIsInSelectedTab<Rigidbody>(Settings._copier_selectedTab))
             {

--- a/Scripts/Editor/PumkinsAvatarTools.cs
+++ b/Scripts/Editor/PumkinsAvatarTools.cs
@@ -1493,6 +1493,7 @@ namespace Pumkin.AvatarTools
                                     Settings.bCopier_dynamicBones_createMissing = GUILayout.Toggle(Settings.bCopier_dynamicBones_createMissing, Strings.Copier.dynamicBones_createMissing, Styles.CopierToggle);
                                     Settings.bCopier_dynamicBones_createObjects = GUILayout.Toggle(Settings.bCopier_dynamicBones_createObjects, Strings.Copier.copyGameObjects, Styles.CopierToggle);
                                     Settings.bCopier_dynamicBones_removeOldBones = GUILayout.Toggle(Settings.bCopier_dynamicBones_removeOldBones, Strings.Copier.dynamicBones_removeOldBones, Styles.CopierToggle);
+                                    Settings.bCopier_dynamicBones_adjustScale = GUILayout.Toggle(Settings.bCopier_dynamicBones_adjustScale, Strings.Copier.bCopier_dynamicBones_adjustScale, Styles.CopierToggle);
                                 }
                             }
 
@@ -1538,6 +1539,7 @@ namespace Pumkin.AvatarTools
                                 {
                                     Settings.bCopier_dynamicBones_removeOldColliders = GUILayout.Toggle(Settings.bCopier_dynamicBones_removeOldColliders, Strings.Copier.dynamicBones_removeOldColliders, Styles.CopierToggle);
                                     Settings.bCopier_dynamicBones_createObjectsColliders = GUILayout.Toggle(Settings.bCopier_dynamicBones_createObjectsColliders, Strings.Copier.copyGameObjects, Styles.CopierToggle);
+                                    Settings.bCopier_dynamicBones_adjustScaleColliders = GUILayout.Toggle(Settings.bCopier_dynamicBones_adjustScaleColliders, Strings.Copier.copyGameObjects, Styles.CopierToggle);
                                 }
                             }
 
@@ -4438,14 +4440,14 @@ namespace Pumkin.AvatarTools
                 {
                     if(Settings.bCopier_dynamicBones_removeOldColliders)
                         LegacyDestroyer.DestroyAllComponentsOfType(objTo, PumkinsTypeCache.DynamicBoneCollider, false, true);
-                    LegacyCopier.CopyAllDynamicBoneColliders(objFrom, objTo, Settings.bCopier_dynamicBones_createObjectsColliders, true);
+                    LegacyCopier.CopyAllDynamicBoneColliders(objFrom, objTo, Settings.bCopier_dynamicBones_createObjectsColliders, true, Settings.bCopier_dynamicBones_adjustScaleColliders);
                 }
                 if(Settings.bCopier_dynamicBones_copy && CopierTabs.ComponentIsInSelectedTab("dynamicbone", Settings._copier_selectedTab))
                 {
                     if(Settings.bCopier_dynamicBones_removeOldBones)
                         LegacyDestroyer.DestroyAllComponentsOfType(objTo, PumkinsTypeCache.DynamicBone, false, true);
                     if(Settings.bCopier_dynamicBones_copySettings || Settings.bCopier_dynamicBones_createMissing)
-                        LegacyCopier.CopyAllDynamicBonesNew(objFrom, objTo, Settings.bCopier_dynamicBones_createMissing, true);
+                        LegacyCopier.CopyAllDynamicBonesNew(objFrom, objTo, Settings.bCopier_dynamicBones_createMissing, true, Settings.bCopier_dynamicBones_adjustScale);
                 }
             }
             else if(Settings.bCopier_dynamicBones_copy)

--- a/Scripts/Editor/PumkinsAvatarTools.cs
+++ b/Scripts/Editor/PumkinsAvatarTools.cs
@@ -1493,7 +1493,7 @@ namespace Pumkin.AvatarTools
                                     Settings.bCopier_dynamicBones_createMissing = GUILayout.Toggle(Settings.bCopier_dynamicBones_createMissing, Strings.Copier.dynamicBones_createMissing, Styles.CopierToggle);
                                     Settings.bCopier_dynamicBones_createObjects = GUILayout.Toggle(Settings.bCopier_dynamicBones_createObjects, Strings.Copier.copyGameObjects, Styles.CopierToggle);
                                     Settings.bCopier_dynamicBones_removeOldBones = GUILayout.Toggle(Settings.bCopier_dynamicBones_removeOldBones, Strings.Copier.dynamicBones_removeOldBones, Styles.CopierToggle);
-                                    Settings.bCopier_dynamicBones_adjustScale = GUILayout.Toggle(Settings.bCopier_dynamicBones_adjustScale, Strings.Copier.bCopier_dynamicBones_adjustScale, Styles.CopierToggle);
+                                    Settings.bCopier_dynamicBones_adjustScale = GUILayout.Toggle(Settings.bCopier_dynamicBones_adjustScale, Strings.Copier.dynamicBones_adjustScale, Styles.CopierToggle);
                                 }
                             }
 
@@ -1539,7 +1539,7 @@ namespace Pumkin.AvatarTools
                                 {
                                     Settings.bCopier_dynamicBones_removeOldColliders = GUILayout.Toggle(Settings.bCopier_dynamicBones_removeOldColliders, Strings.Copier.dynamicBones_removeOldColliders, Styles.CopierToggle);
                                     Settings.bCopier_dynamicBones_createObjectsColliders = GUILayout.Toggle(Settings.bCopier_dynamicBones_createObjectsColliders, Strings.Copier.copyGameObjects, Styles.CopierToggle);
-                                    Settings.bCopier_dynamicBones_adjustScaleColliders = GUILayout.Toggle(Settings.bCopier_dynamicBones_adjustScaleColliders, Strings.Copier.copyGameObjects, Styles.CopierToggle);
+                                    Settings.bCopier_dynamicBones_adjustScaleColliders = GUILayout.Toggle(Settings.bCopier_dynamicBones_adjustScaleColliders, Strings.Copier.dynamicBones_adjustScaleColliders, Styles.CopierToggle);
                                 }
                             }
 

--- a/Scripts/Editor/PumkinsAvatarTools.cs
+++ b/Scripts/Editor/PumkinsAvatarTools.cs
@@ -1795,7 +1795,7 @@ namespace Pumkin.AvatarTools
 
                                     EditorGUILayout.Space();
 
-                                    Settings.bCopier_colliders_removeOld = GUILayout.Toggle(Settings.bCopier_colliders_adjustScale, Strings.Copier.colliders_adjustScale, Styles.CopierToggle);
+                                    Settings.bCopier_colliders_adjustScale = GUILayout.Toggle(Settings.bCopier_colliders_adjustScale, Strings.Copier.colliders_adjustScale, Styles.CopierToggle);
                                     Settings.bCopier_colliders_removeOld = GUILayout.Toggle(Settings.bCopier_colliders_removeOld, Strings.Copier.colliders_removeOld, Styles.CopierToggle);
                                     Settings.bCopier_colliders_createObjects = GUILayout.Toggle(Settings.bCopier_colliders_createObjects, Strings.Copier.copyGameObjects, Styles.CopierToggle);
                                 }

--- a/Scripts/Editor/SettingsContainer.cs
+++ b/Scripts/Editor/SettingsContainer.cs
@@ -89,6 +89,7 @@ namespace Pumkin.AvatarTools
         [SerializeField] internal bool bCopier_colliders_copySphere = true;
         [SerializeField] internal bool bCopier_colliders_copyMesh = false;
         [SerializeField] internal bool bCopier_colliders_createObjects = true;
+        [SerializeField] internal bool bCopier_colliders_adjustScale = true;
 
         [SerializeField] internal bool bCopier_skinMeshRender_copy = true;
         [SerializeField] internal bool bCopier_skinMeshRender_copySettings = true;

--- a/Scripts/Editor/SettingsContainer.cs
+++ b/Scripts/Editor/SettingsContainer.cs
@@ -48,11 +48,13 @@ namespace Pumkin.AvatarTools
         [SerializeField] internal bool bCopier_dynamicBones_copySettings = false;
         [SerializeField] internal bool bCopier_dynamicBones_createMissing = true;
         [SerializeField] internal bool bCopier_dynamicBones_createObjects = false;
+        [SerializeField] internal bool bCopier_dynamicBones_adjustScale = true;
 
         [SerializeField] internal bool bCopier_dynamicBones_copyColliders = true;
         [SerializeField] internal bool bCopier_dynamicBones_removeOldColliders = false;
         [SerializeField] internal bool bCopier_dynamicBones_removeOldBones = false;
         [SerializeField] internal bool bCopier_dynamicBones_createObjectsColliders = true;
+        [SerializeField] internal bool bCopier_dynamicBones_adjustScaleColliders = true;
 
         [SerializeField] internal bool bCopier_descriptor_copy = true;
         [SerializeField] internal bool bCopier_descriptor_copySettings = true;

--- a/Scripts/Editor/Translations/PumkinsTranslation.cs
+++ b/Scripts/Editor/Translations/PumkinsTranslation.cs
@@ -268,12 +268,15 @@ namespace Pumkin.Translations
         public string dynamicBones_removeOldBones = "Remove Old Dynamic Bones";
         public string dynamicBones_removeOldColliders = "Remove Old Colliders";
         public string dynamicBones_createMissing = "Copy Missing Dynamic Bones";
+        public string dynamicBones_adjustScale = "Adjust Scale";
+        public string dynamicBones_adjustScaleColliders = "Adjust Scale";
         public string colliders = "Colliders";
         public string colliders_box = "Box Colliders";
         public string colliders_capsule = "Capsule Colliders";
         public string colliders_sphere = "Sphere Colliders";
         public string colliders_mesh = "Mesh Colliders";
         public string colliders_removeOld = "Remove Old Colliders";
+        public string colliders_adjustScale = "Adjust Scale";
         public string descriptor = "Avatar Descriptor";
         public string descriptor_pipelineId = "Pipeline Id";
         public string descriptor_animationOverrides = "Animation Overrides";


### PR DESCRIPTION
Added Scale Adjustment for copying DynamicBones, DynamicBoneColliders, and regular Colliders between Armatures with different scales.

This assumes uniform scaling on all axis as only the x component of both the destination transform and the source transform is compared
```
public static float GetScaleMultiplier(Transform from, Transform to)
        {
            return from.lossyScale.x / to.lossyScale.x;
        }
```

this addresses Issue #11 