### PR TITLE
Create missing transforms option

### DIFF
--- a/Scripts/Editor/Copiers/LegacyCopier.cs
+++ b/Scripts/Editor/Copiers/LegacyCopier.cs
@@ -497,21 +497,29 @@ namespace Pumkin.AvatarTools.Copiers
                 string log = String.Format(Strings.Log.copyAttempt + " - ", tFrom.gameObject.name, from.name, to.name);
 
                 Transform tTo = Helpers.FindTransformInAnotherHierarchy(tFrom, to.transform, false);
-                if(tTo)
-                {
-                    if(Settings.bCopier_transforms_copyPosition)
-                        tTo.localPosition = tFrom.localPosition;
-                    if(Settings.bCopier_transforms_copyScale)
-                        tTo.localScale = tFrom.localScale;
-                    if(Settings.bCopier_transforms_copyRotation)
-                    {
-                        tTo.localEulerAngles = tFrom.localEulerAngles;
-                        tTo.localRotation = tFrom.localRotation;
+                
+                if(!tTo) {
+                    if (Settings.bCopier_transforms_createMissing) {
+                        Transform targetParent = Helpers.FindTransformInAnotherHierarchy(tFrom.parent, to.transform, false);
+                        GameObject createdObj = UnityEngine.Object.Instantiate(tFrom.gameObject, targetParent);
+                        createdObj.name = tFrom.gameObject.name;
+                        tTo = createdObj.transform;
+                    } else {
+                        PumkinsAvatarTools.Log(log + Strings.Log.failedHasNoIgnoring, LogType.Warning, from.name, tFrom.gameObject.name);
+                        continue;
                     }
-                    PumkinsAvatarTools.Log(log + Strings.Log.success, LogType.Log);
                 }
-                else
-                    PumkinsAvatarTools.Log(log + Strings.Log.failedHasNoIgnoring, LogType.Warning, from.name, tFrom.gameObject.name);
+ 
+                if(Settings.bCopier_transforms_copyPosition)
+                    tTo.localPosition = tFrom.localPosition;
+                if(Settings.bCopier_transforms_copyScale)
+                    tTo.localScale = tFrom.localScale;
+                if(Settings.bCopier_transforms_copyRotation)
+                {
+                    tTo.localEulerAngles = tFrom.localEulerAngles;
+                    tTo.localRotation = tFrom.localRotation;
+                }
+                PumkinsAvatarTools.Log(log + Strings.Log.success, LogType.Log); 
             }
         }
 
@@ -588,7 +596,7 @@ namespace Pumkin.AvatarTools.Copiers
                     }
                     else
                     {
-                        PumkinsAvatarTools.Log(log + Strings.Log.failedDoesntHave, LogType.Warning, rTo.gameObject.name, rFrom.GetType().ToString());
+                        PumkinsAvatarTools.Log(log + Strings.Log.failedDoesntHave, LogType.Warning, tTo.gameObject.name, rFrom.GetType().ToString());
                     }
                 }
             }

--- a/Scripts/Editor/Data/PumkinsStrings.cs
+++ b/Scripts/Editor/Data/PumkinsStrings.cs
@@ -383,6 +383,7 @@ namespace Pumkin.DataStructures
             public static string transforms_position = "_Position";
             public static string transforms_rotation = "_Rotation";
             public static string transforms_scale = "_Scale";
+            public static string transforms_createMissing = "_Create Missing";
             public static string transforms_avatarScale = "_Avatar Scale";
             public static string dynamicBones = "_Dynamic Bones";
             public static string dynamicBones_colliders = "_Dynamic Bone Colliders";
@@ -465,6 +466,7 @@ namespace Pumkin.DataStructures
                 transforms_position = Translation.copier.transforms_position;
                 transforms_rotation = Translation.copier.transforms_rotation;
                 transforms_scale = Translation.copier.transforms_scale;
+                transforms_createMissing = Translation.copier.transforms_createMissing;
                 transforms_avatarScale = Translation.copier.transforms_avatarScale;
                 dynamicBones = Translation.copier.dynamicBones;
                 dynamicBones_colliders = Translation.copier.dynamicBones_colliders;

--- a/Scripts/Editor/PumkinsAvatarTools.cs
+++ b/Scripts/Editor/PumkinsAvatarTools.cs
@@ -1867,6 +1867,7 @@ namespace Pumkin.AvatarTools
                                     Settings.bCopier_transforms_copyPosition = GUILayout.Toggle(Settings.bCopier_transforms_copyPosition, Strings.Copier.transforms_position, Styles.CopierToggle);
                                     Settings.bCopier_transforms_copyRotation = GUILayout.Toggle(Settings.bCopier_transforms_copyRotation, Strings.Copier.transforms_rotation, Styles.CopierToggle);
                                     Settings.bCopier_transforms_copyScale = GUILayout.Toggle(Settings.bCopier_transforms_copyScale, Strings.Copier.transforms_scale, Styles.CopierToggle);
+                                    Settings.bCopier_transforms_createMissing = GUILayout.Toggle(Settings.bCopier_transforms_createMissing, Strings.Copier.transforms_createMissing, Styles.CopierToggle);
                                 }
                             }
 

--- a/Scripts/Editor/SettingsContainer.cs
+++ b/Scripts/Editor/SettingsContainer.cs
@@ -56,6 +56,7 @@ namespace Pumkin.AvatarTools
         [SerializeField] internal bool bCopier_transforms_copyPosition = false;
         [SerializeField] internal bool bCopier_transforms_copyRotation = true;
         [SerializeField] internal bool bCopier_transforms_copyScale = true;
+        [SerializeField] internal bool bCopier_transforms_createMissing = false;
 
         [SerializeField] internal bool bCopier_dynamicBones_copy = true;
         [SerializeField] internal bool bCopier_dynamicBones_copySettings = false;

--- a/Scripts/Editor/Translations/PumkinsTranslation.cs
+++ b/Scripts/Editor/Translations/PumkinsTranslation.cs
@@ -262,6 +262,7 @@ namespace Pumkin.Translations
         public string transforms_position = "Position";
         public string transforms_rotation = "Rotation";
         public string transforms_scale = "Scale";
+        public string transforms_createMissing = "Create Missing";
         public string transforms_avatarScale = "Avatar Scale";
         public string dynamicBones = "Dynamic Bones";
         public string dynamicBones_colliders = "Dynamic Bone Colliders";


### PR DESCRIPTION
# Story

As a VRChat avatar creator I want to be able to copy all of my accessories from one avatar to another because otherwise I would have to do it by hand.

# Changes

Added a new checkbox to automatically create any missing transforms in the target avatar. It is off by default.

# Testing

Works for my Canis Woof avatar which has a bandana accessory and several toggled game objects missing on the target.

Nothing copied:

![image](https://user-images.githubusercontent.com/1967342/148649571-cbed2e03-2bf5-49ea-9812-f279d6178d80.png)

Checkbox OFF:

![image](https://user-images.githubusercontent.com/1967342/148649584-3dd3c7d7-3d6c-47b7-a805-471c1e46a643.png)

Checkbox ON (note bandana is there):

![image](https://user-images.githubusercontent.com/1967342/148649599-86cc4a6e-635d-44fc-b1c8-8f0df69cfffc.png)
