### PR TITLE
Remove VRC Dependency

### DIFF
--- a/Editor/Callbacks/AvatarUploadHider.cs
+++ b/Editor/Callbacks/AvatarUploadHider.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;
 using UnityEngine;
-using VRC.Core;
 
 #if VRC_SDK_VRCSDK3 && !UDON
+using VRC.Core;
 using VRC.SDKBase.Editor.BuildPipeline;
 using VRC_AvatarDescriptor = VRC.SDK3.Avatars.Components.VRCAvatarDescriptor;
 #endif


### PR DESCRIPTION
Unsure if this tool is going VRC-specific now that it is packaged for VCC, but moved VRC.Core namespace reference so I'd stop getting errors when VRCSDK wasn't imported.