### PR TITLE
remove trailing commas in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "An editor script that adds tools to help you setup avatars faster and easier. It includes a component copier that makes it a lot easier to reimport your avatars, and tools to make your thumbnails nicer.",
   "url": "https://github.com/rurre/PumkinsAvatarTools",
   "author": {
-    "name": "Pumkin",
+    "name": "Pumkin"
   },
   "gitDependencies": {},
   "vpmDependencies": {},
@@ -15,5 +15,5 @@
   "license": "MIT",
   "unity": "2019.4",
   "type": "tool",
-  "localPath": ".\\Packages\\io.github.rurre.pumkinsavatartools",
+  "localPath": ".\\Packages\\io.github.rurre.pumkinsavatartools"
 }


### PR DESCRIPTION
the json parser for OpenUPM seems to be json 1.0, not 1.1... which doesn't allow trailing commas sadly

don't think this changes anything for anything other than OpenUPM..