### PR TITLE
Fix compiling for Unity 2021+

### DIFF
--- a/Editor/Helpers/PumkinsHelperFunctions.cs
+++ b/Editor/Helpers/PumkinsHelperFunctions.cs
@@ -1239,7 +1239,7 @@ namespace Pumkin.HelperFunctions
             }
             return found;
         }
-        #elif UNITY_2019
+        #elif UNITY_2019_1_OR_NEWER
         public static bool DestroyMissingScriptsInGameObject(GameObject obj)
         {
             return GameObjectUtility.RemoveMonoBehavioursWithMissingScript(obj) > 0;


### PR DESCRIPTION
Use UNITY_2019_1_OR_NEWER instead of UNITY_2019 compiler flag.

Fixes compiling for ChilloutVR projects.