### PR TITLE
Re-clarified Armature Scale Warnings.

### DIFF
--- a/Editor/Data/PumkinsStrings.cs
+++ b/Editor/Data/PumkinsStrings.cs
@@ -1,4 +1,4 @@
-﻿using Pumkin.AvatarTools;
+using Pumkin.AvatarTools;
 using Pumkin.Translations;
 using System;
 using System.Collections;
@@ -731,8 +731,8 @@ namespace Pumkin.DataStructures
             public static string invalidPreset = "_Can't apply preset {0}: Invalid Preset";
             public static string cantRevertRendererWithoutPrefab = "_Can't revert Skinned Mesh Renderer {0}, object has no Prefab";
             public static string cantLoadImageAtPath = "_Can't load image at {0}";
-            public static string armatureScaleNotOne = "_Armature scale for selected avatar isn't 1! This can cause issues. Please re-export your avatar with CATS' export option";
-            public static string armatureScalesDontMatch = "_Armature scales for selected avatars don't match!\nThis can cause scale issues with some components.";
+            public static string armatureScaleNotOne = "_Armature Scale for selected Avatar is not 1! This can cause issues. Please consider re-exporting your Avatar using FBX Units...\nCheck to make sure you have properly Applied All Transforms to your Model in Blender. When exporting the FBX, please ensure Apply Scalings is set to 'FBX All' in your Export Settings.";
+            public static string armatureScalesDontMatch = "_Armature Scales on the selected Avatars do not match!\nThis can cause scaling issues with some components, such as Phys Bones. Proceed with Caution!";
             public static string noDBonesInProject = "_No DynamicBones found in project";
             public static string languageAlreadyExistsOverwrite = "_Language Asset already exists. Overwrite?";
 

--- a/Editor/Translations/PumkinsTranslation.cs
+++ b/Editor/Translations/PumkinsTranslation.cs
@@ -493,8 +493,8 @@ namespace Pumkin.Translations
         public string invalidPreset = "Can't apply preset {0}: Invalid Preset";
         public string cantRevertRendererWithoutPrefab = "Can't revert Skinned Mesh Renderer {0}, object has no Prefab";
         public string cantLoadImageAtPath = "Can't load image at {0}";
-        public string armatureScaleNotOne = "Armature Scale for selected Avatar is not 1! This can cause issues. Please consider re-exporting your Avatar using FBX Units. See Console for more info.\nBLENDER USERS: Check to make sure you have properly Applied All Transforms to your Model in Blender. When exporting the FBX, please ensure Apply Scalings is set to 'FBX All' in your Export Settings.";
-        public string armatureScalesDontMatch = "Armature Scales on the selected Avatars do not match! This can cause scaling issues with some components, such as Phys Bones. Proceed with Caution!";
+        public string armatureScaleNotOne = "Armature Scale for selected Avatar is not 1! This can cause issues. Please consider re-exporting your Avatar using FBX Units...\nCheck to make sure you have properly Applied All Transforms to your Model in Blender. When exporting the FBX, please ensure Apply Scalings is set to 'FBX All' in your Export Settings.";
+        public string armatureScalesDontMatch = "Armature Scales on the selected Avatars do not match!\nThis can cause scaling issues with some components, such as Phys Bones. Proceed with Caution!";
         public string noDBonesInProject = "No DynamicBones found in project";
         public string languageAlreadyExistsOverwrite = "Language preset already exists. Overwrite?";
     }

--- a/Editor/Translations/PumkinsTranslation.cs
+++ b/Editor/Translations/PumkinsTranslation.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using System;
@@ -493,8 +493,8 @@ namespace Pumkin.Translations
         public string invalidPreset = "Can't apply preset {0}: Invalid Preset";
         public string cantRevertRendererWithoutPrefab = "Can't revert Skinned Mesh Renderer {0}, object has no Prefab";
         public string cantLoadImageAtPath = "Can't load image at {0}";
-        public string armatureScaleNotOne = "Armature scale for selected avatar isn't 1! This can cause issues. Please re-export your avatar with CATS' export option";
-        public string armatureScalesDontMatch = "Armature scales for selected avatars don't match!\nThis can cause scale issues with some components.";
+        public string armatureScaleNotOne = "Armature Scale for selected Avatar is not 1! This can cause issues. Please consider re-exporting your Avatar using FBX Units. See Console for more info.\nBLENDER USERS: Check to make sure you have properly Applied All Transforms to your Model in Blender. When exporting the FBX, please ensure Apply Scalings is set to 'FBX All' in your Export Settings.";
+        public string armatureScalesDontMatch = "Armature Scales on the selected Avatars do not match! This can cause scaling issues with some components, such as Phys Bones. Proceed with Caution!";
         public string noDBonesInProject = "No DynamicBones found in project";
         public string languageAlreadyExistsOverwrite = "Language preset already exists. Overwrite?";
     }


### PR DESCRIPTION
This change has been done because as we both know, CATS is not updated anymore to support Blender 3.0 series.

_*That is, unless you are informed to use the Dev Branch that Felien is maintaining._

HOWEVER, I feel it might be best to not need to mention CATS anymore because it may become irrelevant (or not) if another Tool of similar functionality exists in the future. So instead, I propose we mention to use "FBX Units" instead as a general term for the Armature Scale Warning.

As you look through these changes to the strings, you will find that I think these are somewhat better explanations for the reasoning behind the Warnings and is future-proof. A line break was also added to the main Armature Scale Warning which will describe more information if viewed from the Console, suggesting to the user (assuming they are using Blender to edit their Avatar) to export their FBX using the instructions I written in. Hopefully this is simple enough for most people to understand.