### PR TITLE
Added legacyFolder and legacyPackages to allow VCC to handle Upgrades.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,13 @@
   },
   "gitDependencies": {},
   "vpmDependencies": {},
-  "legacyFolders": {},
+  "legacyFolders": {
+    "Assets\\PumkinsAvatarTools": "a1670ccbbb3658648bb90c2882b40935"
+  },
   "legacyFiles": {},
+  "legacyPackages": [
+    "pumkin.pumkinsavatartools"
+  ],
   "hideInEditor": false,
   "license": "MIT",
   "unity": "2019.4",


### PR DESCRIPTION
This was done because Pumkins Avatar Tools has made changes over time to how it's distributed. Since the latest VCC version now supports removing VCC packages from the `package.json`, I have included the old name `pumkin.pumkinsavatartools` as a legacyPackage. This is a safety measure to allow the VCC to automatically handle removing that old Package automatically when adding the latest Pumkins Avatar Tools version. This should greatly reduce complaints when your VCC Repository is properly used.

In addition, the old `Assets/PumkinsAvatarTools` folder was included in the `legacyFolders` argument. This is an extra safety measure to prevent broken conflicting scripts in case it still exists, allowing the VCC to automatically remove it when adding Pumkin's Avatar Tools. This greatly helps users save a few clicks when adding it to Projects that have older versions included, since the VCC will do that automatically.

I highly suggest you merge this for the next update!

**NOTE TO PUMKIN:** The Package `"version"` number was not bumped yet. I'll let you handle that part on your side.

Thanks!